### PR TITLE
CI/deploy website on tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,5 +25,5 @@ jobs:
           HOSTING_FTP_USERNAME: ${{ secrets.HOSTING_FTP_USERNAME }}
           HOSTING_FTP_PASSWORD: ${{ secrets.HOSTING_FTP_PASSWORD }}
         run: |
-          apt-get install -y ncftp
+          sudo apt-get install -y ncftp
           ncftpput -R -v -u ${HOSTING_FTP_USERNAME} -p ${HOSTING_FTP_PASSWORD} ${HOSTING_FTP_HOST} www/ public/*


### PR DESCRIPTION
@ccamel 
This PR automatically deploys the website **on tag**. 
To prevent public access, there is currently there is a .htaccess on place (see below) that restrict access by IP.

You can update it to add your public IP addresses (IPv4 and IP6), or send me the info so I can do that for you. 

```
order deny,allow
deny from all
Allow from 78.199.198.5 2a01:e34:ec7c:6050:8844:39af:113b:ebba
```
