### PR TITLE
chore(ci): fix hugo build

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,10 +3,14 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
-    <meta name="release" content="{{ .GitInfo.AuthorDate.Format "2006-01-02" }}" />
+    {{ with .GitInfo -}}
+    <meta name="release" content="{{ .AuthorDate.Format "2006-01-02" }}" />    
+    {{- end }}
     <meta name="DC.Publisher" content="{{ .Site.Params.Author }}" />
     <meta name="DC.Date.Issued" content="2020-08-25" />
-    <meta name="DC.Date.Modified" content="{{ .GitInfo.AuthorDate.Format "2006-01-02" }}" />
+    {{ with .GitInfo -}}
+    <meta name="DC.Date.Modified" content="{{ .AuthorDate.Format "2006-01-02" }}" />
+    {{- end }}
 
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
 


### PR DESCRIPTION
Addresses build issue in #26 with the `GitInfo`plugin:

```
Built in 159 ms
Error: Error building site: failed to render pages: render of "section" failed: execute of template failed: template: section/docs.html:4:3: executing "section/docs.html" at <partial "head.html" .>: error calling partial: "/home/rck/dev/repos/src/krossboard-docs/layouts/partials/head.html:6:45": execute of template failed: template: partials/head.html:6:45: executing "partials/head.html" at <.GitInfo.AuthorDate.Format>: nil pointer evaluating *gitmap.GitInfo.AuthorDate
```

I don't know exactly what' going wrong, so I propose to render git info when available.