### PR TITLE
feat: add demo video

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -86,30 +86,9 @@
 
 			<div class="gt20 mb20 middle-md" style="position: relative; margin: 20px;">								
 				<img style="width: 100%;" src="images/mac-blank-screen.png" alt="mac">
-				<div class="carousel-widget ctrl-1" style="display: block; position: absolute; top: 5.6%; width: 75.5%; height: 79.4%; left: 12.3%;"
-					data-nav="true"
-					data-autoplay="true"
-					data-loop="true"
-					data-pager="false"
-					data-itemrange="0,1"
-					data-margin="0"
-					data-autoplay="true"
-					data-hauto="false"
-					data-in="false"
-					data-out="false"
-					data-center="false">
-					<div class="owl-carousel">					
-						<div class="item">
-							<img src="images/docs/screenshorts/krossboard-current-usage-overview.png" alt="Krossboard current usage overview screenshot">
-						</div>	
-						<div class="item">
-							<img src="images/docs/screenshorts/krossboard-cluster-usage-trends.png" alt="Krossboard cluster usage trends screenshot">
-						</div>
-						<div class="item">
-							<img src="images/docs/screenshorts/krossboard-consolidated-clusters-usage.png" alt="Krossboard consolidated clusters usage screenshot">
-						</div>
-					</div>
-				</div>
+				<iframe 
+					style="display: block; position: absolute; top: 5.6%; width: 75.9%; height: 79.4%; left: 12.1%;"
+					src="https://www.youtube.com/embed/lfkUIREDYDY?controls=1"></iframe> 
 			</div><!-- // END : row //  -->
 		</div><!-- // END : container //  -->
 	</section>


### PR DESCRIPTION
This PR adds a demo video (hosted at youtube) in replacement of the caroussel with screenshots.

![image](https://user-images.githubusercontent.com/9574336/98836006-73404c80-2441-11eb-9485-6a7aecd296cc.png)
