### PR TITLE
Specify the same version of Hugo than the one used in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Each contribution should be submitted through a Github [pull request](https://gi
 
 ## Requirements
 
-[Hugo](https://gohugo.io/) static site generator `v0.74.x` minimum (`v0.74.2` is the version currently used by the CI).
+[Hugo](https://gohugo.io/) static site generator `v0.75.x` minimum (`v0.75.1` is the version currently used by the CI).
 
 ```
 sudo snap install hugo --classic

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-min_version = 0.74
+min_version = 0.75
 baseURL = "https://krossboard.app/"
 languageCode = "en-us"
 title = "Krossboard"


### PR DESCRIPTION
In CI, the version used for [Hugo](https://gohugo.io) is `0.75.1` (see [build.yml#L18](https://github.com/2-alchemists/krossboard-docs/blob/master/.github/workflows/build.yml#L18)).