### PR TITLE
Remove useless background block

### DIFF
--- a/layouts/aboutus/aboutus.html
+++ b/layouts/aboutus/aboutus.html
@@ -18,7 +18,6 @@
 				</div>
 			</div>
 		</div>
-		<b class="full-wh z1 bg-rb bg-repeat-x" data-rgen-sm="hide" data-bg="images/intro-graph.svg"></b>
 		<b class="full-wh" data-gradient="y" data-g-colors="rgba(74, 83, 110,1)|rgba(45, 51, 69, 1)"></b>
 	</section>	
 


### PR DESCRIPTION
This PR removes the background block(svg)  which is unnecessary on this page and may produce unwanted visual effects on some browsers.

For instance on `safari`, sometimes I get this display for the `/aboutus`page:

<img width="1066" alt="image" src="https://user-images.githubusercontent.com/9574336/106898038-fba65480-66f3-11eb-9354-79f6e1cf7b19.png">
