### PR TITLE
docs: adopt shields.io with for-the-badge style for badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CC-BY-NC-SA](https://licensebuttons.net/l/by-nc-sa/3.0/88x31.png)](LICENSE.md)
-![build-site](https://github.com/2-alchemists/krossboard-docs/workflows/build%20site/badge.svg)
-![deploy-site](https://github.com/2-alchemists/krossboard-docs/workflows/deploy%20site/badge.svg)
-[![site](https://img.shields.io/badge/%F0%9F%8C%8E-site-blue?style=flat)](https://krossboard.app/)
+[![build-site](https://img.shields.io/github/workflow/status/2-alchemists/krossboard-docs/build%20site?label=build&style=for-the-badge)](https://github.com/2-alchemists/krossboard-docs/actions/workflows/build.yml)
+[![deploy-site](https://img.shields.io/github/workflow/status/2-alchemists/krossboard-docs/deploy%20site?label=deploy&style=for-the-badge)](https://github.com/2-alchemists/krossboard-docs/actions/workflows/deploy.yml)
+[![site](https://img.shields.io/badge/%F0%9F%8C%8E-site-blue?style=for-the-badge)](https://krossboard.app)
 
 # Overview & License
 


### PR DESCRIPTION
Self explanatory. For consistency, propose to use [shields.io](https://shields.io) for rendering badges with the `for-the-badge` looking.

<img width="528" alt="image" src="https://user-images.githubusercontent.com/9574336/170966023-48e1cf85-0b24-4873-9ef3-cf0db13b6e29.png">
